### PR TITLE
Update README for moving repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+**This project has been moved to https://github.com/lib/pq.** 
+This old repository is kept for backward compatibility purposes.
+
 # pq - A pure Go postgres driver for Go's database/sql package
 
 ## Install


### PR DESCRIPTION
It seems that this project has moved to https://github.com/lib/pq?
README should make it clear for future users. 
